### PR TITLE
String mapper field model

### DIFF
--- a/core/src/main/java/io/doov/core/AbstractWrapper.java
+++ b/core/src/main/java/io/doov/core/AbstractWrapper.java
@@ -5,9 +5,7 @@ package io.doov.core;
 
 import java.util.*;
 
-import io.doov.core.serial.*;
-
-public abstract class AbstractWrapper<M> implements FieldModel, StringMapper {
+public abstract class AbstractWrapper<M> implements FieldModel {
 
     protected final List<FieldInfo> fieldInfos;
     protected final M model;
@@ -24,48 +22,6 @@ public abstract class AbstractWrapper<M> implements FieldModel, StringMapper {
     @Override
     public List<FieldInfo> getFieldInfos() {
         return fieldInfos;
-    }
-
-    protected abstract TypeAdapterRegistry getTypeAdapterRegistry();
-
-    @Override
-    public String getAsString(FieldId fieldId) {
-        Object value = get(fieldId);
-        if (value == null) {
-            return null;
-        }
-        return getTypeAdapterRegistry().stream()
-                        .filter(a -> a.accept(value))
-                        .findFirst()
-                        .map(a -> a.toString(value))
-                        .orElse(null);
-    }
-
-    @Override
-    public String getAsString(FieldInfo info) {
-        Objects.requireNonNull(info);
-        return getAsString(info.id());
-    }
-
-    @Override
-    public void setAsString(FieldId fieldId, String value) {
-        FieldInfo fieldInfo = info(fieldId);
-        setAsString(fieldInfo, value);
-    }
-
-    @Override
-    public void setAsString(FieldInfo fieldInfo, String value) {
-        Objects.requireNonNull(fieldInfo);
-        if (value == null) {
-            set(fieldInfo.id(), null);
-        } else {
-            set(fieldInfo.id(), getTypeAdapterRegistry().stream()
-                            .filter(a -> a.accept(fieldInfo))
-                            .findFirst()
-                            .map(a -> a.fromString(fieldInfo, value))
-                            .orElseThrow(() -> new IllegalStateException("cannot set field "
-                                            + fieldInfo.id() + " with value " + value)));
-        }
     }
 
 }

--- a/core/src/main/java/io/doov/core/BaseFieldModel.java
+++ b/core/src/main/java/io/doov/core/BaseFieldModel.java
@@ -19,10 +19,15 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
+import io.doov.core.serial.TypeAdapterRegistry;
+import io.doov.core.serial.TypeAdapters;
+
 /**
  * {@code FieldModel} implementation based on {@code java.util.Map}
  */
 public class BaseFieldModel implements FieldModel {
+
+    private static TypeAdapterRegistry TYPE_ADAPTER_REGISTRY = new TypeAdapters();
 
     protected Map<FieldId, Object> values;
     protected List<FieldInfo> fieldInfos;
@@ -48,6 +53,11 @@ public class BaseFieldModel implements FieldModel {
     @Override
     public List<FieldInfo> getFieldInfos() {
         return fieldInfos;
+    }
+
+    @Override
+    public TypeAdapterRegistry getTypeAdapterRegistry() {
+        return TYPE_ADAPTER_REGISTRY;
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/FieldModel.java
+++ b/core/src/main/java/io/doov/core/FieldModel.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import io.doov.core.dsl.DslModel;
 import io.doov.core.serial.StringMapper;
+import io.doov.core.serial.TypeAdapter;
 
 /**
  * An model that maps {@code FieldId} to values. Each {@code FieldId} can map to at most one value.
@@ -148,12 +149,12 @@ public interface FieldModel extends Iterable<Map.Entry<FieldId, Object>>, DslMod
         if (value == null) {
             set(fieldInfo.id(), null);
         } else {
-            set(fieldInfo.id(), getTypeAdapterRegistry().stream()
-                            .filter(a -> a.accept(fieldInfo))
-                            .findFirst()
-                            .map(a -> a.fromString(fieldInfo, value))
-                            .orElseThrow(() -> new IllegalStateException("cannot set field "
-                                            + fieldInfo.id() + " with value " + value)));
+            TypeAdapter typeAdapter = getTypeAdapterRegistry().stream()
+                    .filter(a -> a.accept(fieldInfo))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("cannot set field "
+                            + fieldInfo.id() + " with value " + value));
+            set(fieldInfo.id(), typeAdapter.fromString(fieldInfo, value));
         }
     }
 

--- a/core/src/main/java/io/doov/core/serial/StringMapper.java
+++ b/core/src/main/java/io/doov/core/serial/StringMapper.java
@@ -8,6 +8,8 @@ import io.doov.core.FieldInfo;
 
 public interface StringMapper {
 
+    TypeAdapterRegistry getTypeAdapterRegistry();
+
     String getAsString(FieldId fieldId);
 
     String getAsString(FieldInfo fieldInfo);

--- a/generator/src/main/resources/io/doov/gen/WrapperClass.template
+++ b/generator/src/main/resources/io/doov/gen/WrapperClass.template
@@ -41,7 +41,7 @@ public final class ${target.class.name} extends ${process.base.class.name} {
     }
 ${constructors}
     @Override
-    protected TypeAdapterRegistry getTypeAdapterRegistry() {
+    public TypeAdapterRegistry getTypeAdapterRegistry() {
         return TYPE_ADAPTER_REGISTRY;
     }
 


### PR DESCRIPTION
FieldModel extends StringMapper interface with default implementations for get/set AsString methods.
Fix for bug preventing a TypeAdapter to set null value on a field.
